### PR TITLE
include zip_safe=False in setup function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,5 @@ setuptools.setup(
     license='GPLv3',
     include_package_data=True,
     python_requires='~=3.5',
+    zip_safe=False,
 )


### PR DESCRIPTION
The reason this should be included is that Swift will not load plug-ins from zipped packages. By default, setuptools analyzes packages to determine whether it is safe to install them in zipped form (see https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag for details). This can lead to unexpected behavior when installing plug-ins with `python setup.py install` and be very difficult to debug for inexperienced developers because some packages may work while others don't. `zip_safe=False` will ensure that packages will always be installed in unzipped form and developers will not be confused by the fact that Swift "randomly" detects some plug-ins while it ignores others.